### PR TITLE
Add timeout when receiver is not found after 5 seconds

### DIFF
--- a/localite/coil.py
+++ b/localite/coil.py
@@ -6,7 +6,7 @@ from functools import partial
 from localite.flow.mrk import Receiver
 from typing import Tuple, Dict, Any, Union
 import json
-from time import sleep
+import time
 
 def pythonize_values(v: str) -> Union[bool, None, str]:
     "pythonize a dictionaries values"
@@ -54,7 +54,10 @@ class Coil:
         self._push_loc = partial(push, fmt="loc", host=host, port=port)
         self.receiver = Receiver(name="localite_marker")
         self.receiver.start()
+        start_receiver_time = time.time()
         while not self.receiver.is_running.is_set():
+            if time.time() > start_receiver_time + timeout:
+                raise ConnectionError("Could not connect to localite flow")
             pass
         self.id = coil
 

--- a/localite/coil.py
+++ b/localite/coil.py
@@ -48,7 +48,7 @@ class Coil:
     
     """
 
-    def __init__(self, coil: int = 0, address: Tuple[str, int] = ("127.0.0.1", 6667)):
+    def __init__(self, coil: int = 0, address: Tuple[str, int] = ("127.0.0.1", 6667), timeout=10):
         host, port = address
         self._push_mrk = partial(push, fmt="mrk", host=host, port=port)
         self._push_loc = partial(push, fmt="loc", host=host, port=port)


### PR DESCRIPTION
This tries to solve the problem that a user not familiar with the setup forgot to activate the localite-flow but has a hard time of finding the source of the problem